### PR TITLE
Adding possibility to post to main thread

### DIFF
--- a/SwiftEventBus/SwiftEventBus.swift
+++ b/SwiftEventBus/SwiftEventBus.swift
@@ -38,6 +38,37 @@ public class SwiftEventBus {
     public class func post(name: String, sender: AnyObject?, userInfo: [NSObject : AnyObject]?) {
         NSNotificationCenter.defaultCenter().postNotificationName(name, object: sender, userInfo: userInfo)
     }
+    
+    public class func postToMainThread(name: String) {
+        dispatch_async(dispatch_get_main_queue()) {
+            NSNotificationCenter.defaultCenter().postNotificationName(name, object: nil)
+        }
+    }
+    
+    public class func postToMainThread(name: String, sender: AnyObject?) {
+        dispatch_async(dispatch_get_main_queue()) {
+            NSNotificationCenter.defaultCenter().postNotificationName(name, object: sender)
+        }
+    }
+    
+    public class func postToMainThread(name: String, sender: NSObject?) {
+        dispatch_async(dispatch_get_main_queue()) {
+            NSNotificationCenter.defaultCenter().postNotificationName(name, object: sender)
+        }
+    }
+    
+    public class func postToMainThread(name: String, userInfo: [NSObject : AnyObject]?) {
+        dispatch_async(dispatch_get_main_queue()) {
+            NSNotificationCenter.defaultCenter().postNotificationName(name, object: nil, userInfo: userInfo)
+        }
+    }
+    
+    public class func postToMainThread(name: String, sender: AnyObject?, userInfo: [NSObject : AnyObject]?) {
+        dispatch_async(dispatch_get_main_queue()) {
+            NSNotificationCenter.defaultCenter().postNotificationName(name, object: sender, userInfo: userInfo)
+        }
+    }
+    
 
     
     ////////////////////////////////////


### PR DESCRIPTION
Right now Swift Event Bus isn't ready to post to the main thread when in a background thread.

Imagine you have a button and a textField. Each time you click the button, we fire a post to the background and the a post from there to the main thread. Instead of calling post, we call postToMainThread.

```swift

@IBAction func clicked(sender: AnyObject) {
     count++
     SwiftEventBus.post("doStuffOnBackground")
 }
    
 @IBOutlet weak var textField: UITextField!
    
 var count = 0
    
 override func viewDidLoad() {
     super.viewDidLoad()

     SwiftEventBus.onBackgroundThread(self, name: "doStuffOnBackground") { notification in
         println("doing stuff in background thread")
         SwiftEventBus.postToMainThread("updateText")
     }
        
     SwiftEventBus.onMainThread(self, name: "updateText") { notification in
         self.textField.text = "\(self.count)"
     }
-```