### PR TITLE
Added @discardableResult

### DIFF
--- a/SwiftEventBus/SwiftEventBus.swift
+++ b/SwiftEventBus/SwiftEventBus.swift
@@ -75,6 +75,7 @@ open class SwiftEventBus {
     // Subscribe
     ////////////////////////////////////
     
+    @discardableResult
     open class func on(_ target: AnyObject, name: String, sender: AnyObject?, queue: OperationQueue?, handler: @escaping ((Notification!) -> Void)) -> NSObjectProtocol {
         let id = UInt(bitPattern: ObjectIdentifier(target))
         let observer = NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: name), object: sender, queue: queue, using: handler)
@@ -91,18 +92,22 @@ open class SwiftEventBus {
         return observer
     }
     
+    @discardableResult
     open class func onMainThread(_ target: AnyObject, name: String, handler: @escaping ((Notification!) -> Void)) -> NSObjectProtocol {
         return SwiftEventBus.on(target, name: name, sender: nil, queue: OperationQueue.main, handler: handler)
     }
     
+    @discardableResult
     open class func onMainThread(_ target: AnyObject, name: String, sender: AnyObject?, handler: @escaping ((Notification!) -> Void)) -> NSObjectProtocol {
         return SwiftEventBus.on(target, name: name, sender: sender, queue: OperationQueue.main, handler: handler)
     }
     
+    @discardableResult
     open class func onBackgroundThread(_ target: AnyObject, name: String, handler: @escaping ((Notification!) -> Void)) -> NSObjectProtocol {
         return SwiftEventBus.on(target, name: name, sender: nil, queue: OperationQueue(), handler: handler)
     }
     
+    @discardableResult
     open class func onBackgroundThread(_ target: AnyObject, name: String, sender: AnyObject?, handler: @escaping ((Notification!) -> Void)) -> NSObjectProtocol {
         return SwiftEventBus.on(target, name: name, sender: sender, queue: OperationQueue(), handler: handler)
     }


### PR DESCRIPTION
Adding @discardableResult notation  will remove the following warning:

> Result of call to 'onMainThread(_:name:handler:)' is unused 

And other similar.